### PR TITLE
add `-shell-escape` option

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,11 +1,13 @@
 #!/usr/bin/env perl
-$latex            = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex -synctex=1 -interaction=nonstopmode -halt-on-error";
-$latex_silent     = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex -synctex=1 -interaction=batchmode -halt-on-error";
-$bibtex           = "upbibtex";
-$biber            = "biber --bblencoding=utf8 -u -U --output_safechars";
+$latex            = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex %O -synctex=1 -halt-on-error -interaction=nonstopmode -shell-escape -file-line-error %S";
+$latex_silent     = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex %O -synctex=1 -halt-on-error -interaction=batchmode -shell-escape -file-line-error %S";
+$bibtex           = "upbibtex -kanji=utf8 %O %B";
+$biber            = "biber %O --bblencoding=utf8 -u -U --output_safechars %B";
 $dvipdf           = "dvipdfmx %O -o %D %S";
 $makeindex        = "upmendex %O -o %D %S";
 $max_repeat       = 5;
+$dvips            = "dvips %O -z -f %S | convbkmk -u > %D";
+$ps2pdf           = "ps2pdf %O %S %D";
 $pdf_mode         = 3;
 $pdf_previewer    = ":"; # do nothing
 $out_dir          = "out";

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,13 +1,11 @@
 #!/usr/bin/env perl
-$latex            = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex %O -synctex=1 -halt-on-error -interaction=nonstopmode -shell-escape -file-line-error %S";
-$latex_silent     = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex %O -synctex=1 -halt-on-error -interaction=batchmode -shell-escape -file-line-error %S";
-$bibtex           = "upbibtex -kanji=utf8 %O %B";
-$biber            = "biber %O --bblencoding=utf8 -u -U --output_safechars %B";
+$latex            = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex -synctex=1 -interaction=nonstopmode -shell-escape -halt-on-error";
+$latex_silent     = "find . -type f -name '*.tex' -print0 | xargs -0 sed -i -e 's/、/，/g' -e 's/。/．/g' && uplatex -synctex=1 -interaction=batchmode -shell-escape -halt-on-error";
+$bibtex           = "upbibtex";
+$biber            = "biber --bblencoding=utf8 -u -U --output_safechars";
 $dvipdf           = "dvipdfmx %O -o %D %S";
 $makeindex        = "upmendex %O -o %D %S";
 $max_repeat       = 5;
-$dvips            = "dvips %O -z -f %S | convbkmk -u > %D";
-$ps2pdf           = "ps2pdf %O %S %D";
 $pdf_mode         = 3;
 $pdf_previewer    = ":"; # do nothing
 $out_dir          = "out";

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ If you want to install all packages of TeX Live, pull `arkark/latexmk:full` whos
     ```console
     $ docker run --rm -it -v $PWD:/workdir arkark/latexmk
     ```
+    If you use Windows, execute in PowerShell:
+
+    ```console
+    > docker run --rm -it -v "$(pwd):/workdir" arkark/latexmk
+    ```
+
 4. Edit latex files and preview `out/main.pdf` while monitoring a latexmk's log.
 5. Press `Ctrl+C` to exit.
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,9 @@ If you want to install all packages of TeX Live, pull `arkark/latexmk:full` whos
     $ docker run --rm -it -v $PWD:/workdir arkark/latexmk
     ```
     If you use Windows, execute in PowerShell:
-
     ```console
     > docker run --rm -it -v "$(pwd):/workdir" arkark/latexmk
     ```
-
 4. Edit latex files and preview `out/main.pdf` while monitoring a latexmk's log.
 5. Press `Ctrl+C` to exit.
 


### PR DESCRIPTION
The source code paste package [minted](https://www.ctan.org/pkg/minted) requires `-shell-escape` as an option at runtime, so we added it.
And added windows usage.