### PR TITLE
copy .latexmkrc when Mac or Windows

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -17,7 +17,9 @@ if ! test -z "${USER_ID:-}" && ! test -z "${GROUP_ID:-}"; then
   exec gosu user "$@"
 
 elif test -z "${USER_ID:-}" && test -z "${GROUP_ID:-}"; then
-  # Mac
+  # Mac or Windows
+
+  cp /tmp/latexmk/.latexmkrc /root/
 
   exec "$@"
 


### PR DESCRIPTION
Lack of .latexmkrc when Mac or Windows, so I added.