### PR TITLE
update texlive from 2020 -> 2021

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@
 # Released under the MIT license
 # https://opensource.org/licenses/MIT
 
-FROM ubuntu:eoan
+FROM ubuntu
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS=yes
-ENV PATH="/usr/local/texlive/2020/bin/x86_64-linux:$PATH"
+ENV YEAR "2021"
+ENV PATH="/usr/local/texlive/${YEAR}/bin/x86_64-linux:$PATH"
+
 
 RUN apt-get update \
     && apt-get -y install \
@@ -24,7 +26,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install pygments \
     && mkdir /tmp/install-tl-unx \
-    && wget -O - ftp://tug.org/historic/systems/texlive/2020/install-tl-unx.tar.gz \
+    && wget -O - ftp://tug.org/historic/systems/texlive/${YEAR}/install-tl-unx.tar.gz \
         | tar -xzv -C /tmp/install-tl-unx --strip-components=1 \
     && /bin/echo -e 'selected_scheme scheme-basic\ntlpdbopt_install_docfiles 0\ntlpdbopt_install_srcfiles 0' \
         > /tmp/install-tl-unx/texlive.profile \

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -2,11 +2,12 @@
 # Released under the MIT license
 # https://opensource.org/licenses/MIT
 
-FROM ubuntu:eoan
+FROM ubuntu
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS=yes
-ENV PATH="/usr/local/texlive/2020/bin/x86_64-linux:$PATH"
+ENV YEAR "2021"
+ENV PATH="/usr/local/texlive/${YEAR}/bin/x86_64-linux:$PATH"
 
 RUN apt-get update \
     && apt-get -y install \
@@ -24,7 +25,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install pygments \
     && mkdir /tmp/install-tl-unx \
-    && wget -O - ftp://tug.org/historic/systems/texlive/2020/install-tl-unx.tar.gz \
+    && wget -O - ftp://tug.org/historic/systems/texlive/${YEAR}/install-tl-unx.tar.gz \
         | tar -xzv -C /tmp/install-tl-unx --strip-components=1 \
     && /bin/echo -e 'selected_scheme scheme-full\ntlpdbopt_install_docfiles 0\ntlpdbopt_install_srcfiles 0' \
         > /tmp/install-tl-unx/texlive.profile \


### PR DESCRIPTION
+ updated texlive urls from 2020 -> 2021
- removed ubuntu:eoan tag as it has reached EOL